### PR TITLE
Poing to rh-dev instead of remote-vllm distribution

### DIFF
--- a/llama-stack-with-config/llama-stack-with-config.yaml
+++ b/llama-stack-with-config/llama-stack-with-config.yaml
@@ -12,6 +12,6 @@ spec:
       name: llama-stack
       port: 8321
     distribution:
-      name: remote-vllm
+      name: rh-dev
     userConfig:
       configMapName: llama-stack-config


### PR DESCRIPTION
Using remove-vllm gives the next error:
  failed to reconcile Deployment: failed to validate distribution:
  remote-vllm. Distribution name not supported